### PR TITLE
Use Date.now() instead of (new Date()).getTime()

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -37,7 +37,7 @@ function eventProxy(from, to, name) {
 //Gets the current time in milliseconds since epoch
 //return : Number
 function curTime() {
-    return new Date().getTime();
+    return Date.now();
 }
 
 //Creates an error object


### PR DESCRIPTION
Date.now() is shown to be faster than (new Date()).getTime()

http://jsperf.com/date-now-vs-new-date-gettime
