### PR TITLE
Enable manipulation of the context/ the methods after the Server has started.

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -90,8 +90,24 @@ function Server(context) {
 
 nodeUtil.inherits(Server, events.EventEmitter);
 
-Server.prototype.expose = function(key, callback, force) {
-    console.log(arguments, "exposed");
+Server.prototype.expose = function(name, method) {
+    // use 'publicMethods'
+    var context = {};
+    context[name] = method;
+    var methods = publicMethods(context);
+    for(var _name in methods) {
+        this._methods[_name] = methods[_name];
+    }
+    this._context[name] = method;
+    return this;
+};
+
+Server.prototype.unexpose = function(name) {
+    if(name in this._methods && name in this._context) {
+        delete this._methods[name];
+        delete this._context[name];
+    }
+    return this;
 };
 
 //Creates the new-school introspector

--- a/lib/server.js
+++ b/lib/server.js
@@ -91,13 +91,15 @@ function Server(context) {
 nodeUtil.inherits(Server, events.EventEmitter);
 
 Server.prototype.expose = function(name, method) {
-    // use 'publicMethods'
+    // use 'publicMethods' to use the same naming constraint
     var context = {};
     context[name] = method;
     var methods = publicMethods(context);
-    for(var _name in methods) {
-        this._methods[_name] = methods[_name];
+    // only extend this._methods when the method is 'public'
+    if(name in methods) {
+        this._methods[name] = methods[name];
     }
+    // add to this._context anyway
     this._context[name] = method;
     return this;
 };

--- a/lib/server.js
+++ b/lib/server.js
@@ -78,9 +78,9 @@ function Server(context) {
     self._context = context || {};
     self._methods = publicMethods(self._context);
 
-    var newInspector = self._createIntrospector(context.constructor.name || "Object");
+    var newInspector = self._createIntrospector(self._context.constructor.name || "Object");
 
-    context._zerorpc_inspect = newInspector;
+    self._context._zerorpc_inspect = newInspector;
     self._methods._zerorpc_inspect = getArguments(newInspector);
 
     self._socket.on("multiplexing-socket/receive", function(event) {

--- a/lib/server.js
+++ b/lib/server.js
@@ -75,7 +75,8 @@ function Server(context) {
     self._socket = socket.server();
     util.eventProxy(self._socket, self, "error");
 
-    self._methods = publicMethods(context);
+    self._context = context || {};
+    self._methods = publicMethods(self._context);
 
     var newInspector = self._createIntrospector(context.constructor.name || "Object");
 
@@ -83,11 +84,15 @@ function Server(context) {
     self._methods._zerorpc_inspect = getArguments(newInspector);
 
     self._socket.on("multiplexing-socket/receive", function(event) {
-        if(event.name in self._methods) self._recv(event, context);
+        if(event.name in self._methods) self._recv(event, self._context);
     });
 }
 
 nodeUtil.inherits(Server, events.EventEmitter);
+
+Server.prototype.expose = function(key, callback, force) {
+    console.log(arguments, "exposed");
+};
 
 //Creates the new-school introspector
 Server.prototype._createIntrospector = function(contextName) {


### PR DESCRIPTION
I added an 'expose' and an 'unexpose' method that manipulate the context of the server by simply keeping track of the context object. This is very useful when the exposed methods are unknown at the time the server is instantiated.