### PR TITLE
Fix channel memory leak.

### DIFF
--- a/lib/channel.js
+++ b/lib/channel.js
@@ -147,7 +147,7 @@ Channel.prototype.flush = function() {
         this._outBuffer.decrementCapacity();
     }
 
-    if(this.state == CHANNEL_CLOSING && this._outBuffer.length() == 0) {
+    if(this._state == CHANNEL_CLOSING && this._outBuffer.length() == 0) {
         this._state = CHANNEL_CLOSED;
         delete this._socket.channels[this.id];
         this.emit("closed");


### PR DESCRIPTION
Channels were never getting cleaned up.  This commit (fixing a typo) should allow for `Channel.close` to properly work.
