### PR TITLE
Update server error properties name to match client and protocol doc

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -126,7 +126,7 @@ Server.prototype._recv = function(event, context) {
 
     //Sends an error
     var sendError = function(error) {
-        var args = [error.type || "Error", error.message, error.stack];
+        var args = [error.name || "Error", error.message, error.traceback];
         ch.send("ERR", args);
         ch.close();
     };


### PR DESCRIPTION
The client decodes the error properties as "name", "message" and
"traceback" (util.js:53). However, the server expects the error
properties to be named "type", "message" and "stack". The protocol
doc seems to indicate the client properties are correct and that the
properties are "name", "message" and "traceback".

https://github.com/dotcloud/zerorpc-python/blob/master/doc/protocol.md
