### PR TITLE
Update client error properties name to match server

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -41,16 +41,16 @@ function curTime() {
 }
 
 //Creates an error object
-//name : String
-//      The error name
+//type : String
+//      The error type
 //message : String
 //      The error message
-//traceback : String
+//stack : String
 //      The exception stack trace as a string
 //return : Object
 //      An error object
-function createErrorResponse(name, message, traceback) {
-    return { name: name, message: message, traceback: traceback };
+function createErrorResponse(type, message, stack) {
+    return { type: type, message: message, stack: stack };
 }
 
 exports.eventProxy = eventProxy;


### PR DESCRIPTION
The server expects the error properties to be named "type", "message"
and "stack" (server.js:129). However, the client serialize the error
back as "name", "message" and "traceback". This causes the properties
to be lost when an error is passed through multiple servers before
being returned to a client.