### PR TITLE
Add builtin _zerorpc_ping method

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -82,6 +82,9 @@ function Server(context, heartbeat) {
 
     self._methods = publicMethods(context);
 
+    context._zerorpc_ping = function(reply) { reply(null, ["pong",""]); };
+    self._methods._zerorpc_ping = [];
+
     var newInspector = self._createIntrospector(context.constructor.name || "Object");
 
     context._zerorpc_inspect = newInspector;


### PR DESCRIPTION
The protocol doc mentions a _zerorpc_ping method. This implements
the _zerorpc_ping method with a return value compatible with the
Python implementation.