### PR TITLE
Bump msgpack dependency to 0.2.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
 
     "dependencies": {
         "underscore": "1.3.3",
-        "msgpack": "0.1.8",
+        "msgpack": "0.2.4",
         "node-uuid": "1.3.3",
         "zmq": "2.x"
     },


### PR DESCRIPTION
The 0.2.x release of msgpack adds toJSON compatibility to control
how objects are serialized. This is particularly useful if you want
to hide some properties (or object functions) from being serialized
and sent through ZeroRPC.