### PR TITLE
Fix memory leak in channel timeout

### DIFF
--- a/lib/channel.js
+++ b/lib/channel.js
@@ -97,7 +97,7 @@ Channel.prototype.invoke = function(event) {
             self.flush();
         } else {
             self.emit("protocol-error", "Invalid event: Bad buffer message");
-            self.close();
+            self.destroy();
         }
     } else if(event.name == "_zpc_hb") {
         self._resetHeartbeat();
@@ -135,11 +135,18 @@ Channel.prototype.invoke = function(event) {
 
 //Puts the channel in the closing state
 Channel.prototype.close = function() {
-    clearTimeout(this._heartbeatRunner);
     this._state = CHANNEL_CLOSING;
     this.emit("closing");
     this.flush();
 };
+
+//Close and destroy channel
+Channel.prototype.destroy = function() {
+    this._state = CHANNEL_CLOSED;
+    this.emit("closed");
+    clearTimeout(this._heartbeatRunner);
+    delete this._socket.channels[this.id];
+}
 
 //Sends as many outbound messages as possible
 Channel.prototype.flush = function() {
@@ -149,9 +156,7 @@ Channel.prototype.flush = function() {
     }
 
     if(this._state == CHANNEL_CLOSING && this._outBuffer.length() == 0) {
-        this._state = CHANNEL_CLOSED;
-        delete this._socket.channels[this.id];
-        this.emit("closed");
+        this.destroy();
     }
 };
 
@@ -191,7 +196,7 @@ Channel.prototype._runHeartbeat = function() {
             //If we haven't received a response in 2 * heartbeat rate, send an
             //error
             self.emit("heartbeat-error", "Lost remote after " + (self._heartbeatInterval * 2) + "ms");
-            self.close();
+            self.destroy();
         }
         
         //Heartbeat on the channel

--- a/lib/middleware.js
+++ b/lib/middleware.js
@@ -38,7 +38,7 @@ function addTimeout(timeout, channel, callback) {
     });
 
     //Clear the timeout when the channel is closed
-    channel.on("closing", function() {
+    channel.on("closed", function() {
         clearTimeout(runner);
     });
 }

--- a/lib/socket.js
+++ b/lib/socket.js
@@ -133,7 +133,7 @@ MultiplexingSocket.prototype.close = function(linger) {
     }
 
     this._zmqSocket.close();
-    for(var id in this.channels) this.channels[id].close();
+    for(var id in this.channels) this.channels[id].destroy();
 };
 
 MultiplexingSocket.prototype.setTimeout = function(timeout) {


### PR DESCRIPTION
Channel was not being properly closed on channel timeout. Close was
issuing flush, which wait for the channel to empty its output buffer.
For a channel in timeout (or error) state, this would wait forever
and leave the channel in closing state and preventing the output
buffer from being freed.