### PR TITLE
Updates msgpack version, 0.1.8 doesn't compile with node 0.12

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
 
     "dependencies": {
         "underscore": "1.3.3",
-        "msgpack": "0.1.8",
+        "msgpack": "0.2.6",
         "node-uuid": "1.3.3",
         "zmq": "2.x"
     },


### PR DESCRIPTION
msgpack version 0.1.8 doesn't compile with node 0.12. The latest compiles cleanly.