### PR TITLE
Bump up the version number to accommodate recent bugfixes

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "zerorpc",
-    "version": "0.9.3",
+    "version": "0.9.4",
     "main": "./index.js",
     "author": "dotCloud <opensource@dotcloud.com>",
     "description": "A port of ZeroRPC to node.js",


### PR DESCRIPTION
There was a critical memory leak bug which was fixed, but the new version has not been released in the public npm registry. Please do this asap. Thanks.