### PR TITLE
callbackErrorWrapper being called twice

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -88,8 +88,13 @@ Client.prototype.invoke = function(method /*, args..., callback*/) {
     var args = Array.prototype.slice.call(arguments, 1,
             hasCallback ? arguments.length - 1 : arguments.length);
 
+    var alreadyCalled = false;
+
     var callbackErrorWrapper = function(error) {
-        callback(error, undefined, false);
+        if(alreadyCalled === false) {
+            callback(error, undefined, false);
+            alreadyCalled = true;
+        }
     };
 
     var ch = self._socket.openChannel();
@@ -121,7 +126,7 @@ Client.prototype.invoke = function(method /*, args..., callback*/) {
             ch.close();
         }
     };
-    
+
     ch.register(function(event) {
         var handler = handlers[event.name];
 


### PR DESCRIPTION
With a small timeout value (3 seconds) the ```callbackErrorWrapper``` was being called twice.  The middleware timeout was being invoked as well as the ```'ERR'``` handler.  I added a simple boolean to make sure it's only invoked once.