### PR TITLE
Clean up variable declaration pattern

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -38,11 +38,11 @@ var DEFAULT_HEARTBEAT = 5000;
 //      Options associated with the client. Allowed options:
 //      * timeout (number): Seconds to wait for a response before it is
 //        considered timed out (default 30s)
-//      * heartbeatInterval (number): The heartbeat interval in ms. 
+//      * heartbeatInterval (number): The heartbeat interval in ms.
 //        (default 5000ms)
 function Client(options) {
     options = options || {};
-    var heartbeat = options.heartbeatInterval || DEFAULT_HEARTBEAT
+    var heartbeat = options.heartbeatInterval || DEFAULT_HEARTBEAT;
     this._timeout = options.timeout || DEFAULT_TIMEOUT;
 	this._socket = socket.client(heartbeat);
 
@@ -82,10 +82,10 @@ Client.prototype.closed = function() {
 //callback : Function
 //      The callback to call on an update
 Client.prototype.invoke = function(method /*, args..., callback*/) {
-    var self = this,
-        hasCallback = typeof arguments[arguments.length - 1] == 'function',
-        callback = hasCallback ? arguments[arguments.length - 1] : function() {},
-        args = Array.prototype.slice.call(arguments, 1, 
+    var self = this;
+    var hasCallback = typeof arguments[arguments.length - 1] == 'function';
+    var callback = hasCallback ? arguments[arguments.length - 1] : function() {};
+    var args = Array.prototype.slice.call(arguments, 1,
             hasCallback ? arguments.length - 1 : arguments.length);
 
     var callbackErrorWrapper = function(error) {

--- a/lib/events.js
+++ b/lib/events.js
@@ -84,8 +84,8 @@ function create(envelope, header, name, args) {
     };
 }
 
-var uuidBase = uuid.v4().substring(0, 24),
-    uuidCounter = 0;
+var uuidBase = uuid.v4().substring(0, 24);
+var uuidCounter = 0;
 
 function fastUUID() {
     var counter = uuidCounter++;

--- a/lib/server.js
+++ b/lib/server.js
@@ -37,9 +37,9 @@ var DEFAULT_HEARTBEAT = 5000;
 //return : Array of Strings
 //      The function's arguments
 function getArguments(fun) {
-    var m1 = /^[\s\(]*function[^(]*\(([^)]*)\)/,
-        m2 = /\/\/.*?[\r\n]|\/\*(?:.|[\r\n])*?\*\//g,
-        m3 = /\s+/g;
+    var m1 = /^[\s\(]*function[^(]*\(([^)]*)\)/;
+    var m2 = /\/\/.*?[\r\n]|\/\*(?:.|[\r\n])*?\*\//g;
+    var m3 = /\s+/g;
 
     var names = fun.toString().match(m1)[1].replace(m2, '').replace(m3, '').split(',');
     var args = names.length == 1 && !names[0] ? [] : names;
@@ -73,8 +73,8 @@ function publicMethods(context) {
 // context : Object
 //      The object to expose
 function Server(context, heartbeat) {
-    var self = this
-      , heartbeat = heartbeat || DEFAULT_HEARTBEAT;
+    var self = this;
+    var heartbeat = heartbeat || DEFAULT_HEARTBEAT;
 
 
     self._socket = socket.server(heartbeat);


### PR DESCRIPTION
I noticed there seemed to be a lot of `var` declaration patterns throughout the files in `lib` (eg: single `var` keyword with multiple variables separated by comma, a leading commas vs. trailing commas, a `var` keyword per declaration, etc) and I thought it could benefit from a little clean up/consistency. 

It seemed like a `var` keyword per variable declaration was the most common, so that's the pattern I followed. Also added a missing semi-colon.

I left the dependency declaration alone because it was consistent throughout. 