### PR TITLE
Allow timeouts to be overridden per call.

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -83,16 +83,17 @@ Client.prototype.closed = function() {
 //      The arguments to send with the invocation
 //callback : Function
 //      The callback to call on an update
-Client.prototype.invoke = function(options, method /*, args..., callback*/) {
+Client.prototype.invoke = function(/*options, */method /*, args..., callback*/) {
     var self = this;
     var hasCallback = typeof arguments[arguments.length - 1] == 'function';
     var callback = hasCallback ? arguments[arguments.length - 1] : function() {};
+    var options = typeof method === 'object' ?
+        method :
+        undefined;
     var offset = 1;
-    if (typeof options === 'object') {
+    if (options === method) {
+        method = arguments[1];
         offset = 2;
-    } else {
-        method = options;
-        options = undefined;
     }
     var args = Array.prototype.slice.call(arguments, offset,
             hasCallback ? arguments.length - 1 : arguments.length);

--- a/lib/client.js
+++ b/lib/client.js
@@ -81,11 +81,18 @@ Client.prototype.closed = function() {
 //      The arguments to send with the invocation
 //callback : Function
 //      The callback to call on an update
-Client.prototype.invoke = function(method /*, args..., callback*/) {
+Client.prototype.invoke = function(options, method /*, args..., callback*/) {
     var self = this;
     var hasCallback = typeof arguments[arguments.length - 1] == 'function';
     var callback = hasCallback ? arguments[arguments.length - 1] : function() {};
-    var args = Array.prototype.slice.call(arguments, 1,
+    var offset = 1;
+    if (typeof options === 'object') {
+        offset = 2;
+    } else {
+        method = options;
+        options = {};
+    }
+    var args = Array.prototype.slice.call(arguments, offset,
             hasCallback ? arguments.length - 1 : arguments.length);
 
     var alreadyCalled = false;
@@ -98,7 +105,8 @@ Client.prototype.invoke = function(method /*, args..., callback*/) {
     };
 
     var ch = self._socket.openChannel();
-    middleware.addTimeout(self._timeout * 1000, ch, callbackErrorWrapper);
+    var timeout = options.timeout || self._timeout);
+    middleware.addTimeout(timeout * 1000, ch, callbackErrorWrapper);
 
     //Associated callbacks to execute for various events
     var handlers = {

--- a/lib/client.js
+++ b/lib/client.js
@@ -107,7 +107,7 @@ Client.prototype.invoke = function(options, method /*, args..., callback*/) {
     };
 
     var ch = self._socket.openChannel();
-    var timeout = parseInt(options && options.timeout, 10) || self._timeout);
+    var timeout = parseInt(options && options.timeout, 10) || self._timeout;
     middleware.addTimeout(timeout * 1000, ch, callbackErrorWrapper);
 
     //Associated callbacks to execute for various events

--- a/lib/client.js
+++ b/lib/client.js
@@ -75,6 +75,8 @@ Client.prototype.closed = function() {
 };
 
 //Calls a remote method
+//options: Object
+//      Optional options object to override the constructor options (currently only timeout)
 //method : String
 //      The method name
 //args... : Varargs
@@ -90,7 +92,7 @@ Client.prototype.invoke = function(options, method /*, args..., callback*/) {
         offset = 2;
     } else {
         method = options;
-        options = {};
+        options = undefined;
     }
     var args = Array.prototype.slice.call(arguments, offset,
             hasCallback ? arguments.length - 1 : arguments.length);
@@ -105,7 +107,7 @@ Client.prototype.invoke = function(options, method /*, args..., callback*/) {
     };
 
     var ch = self._socket.openChannel();
-    var timeout = options.timeout || self._timeout);
+    var timeout = parseInt(options && options.timeout, 10) || self._timeout);
     middleware.addTimeout(timeout * 1000, ch, callbackErrorWrapper);
 
     //Associated callbacks to execute for various events

--- a/test/timeouts.js
+++ b/test/timeouts.js
@@ -55,5 +55,20 @@ module.exports = {
 			test.equal(more, false);
 			test.done();
 		});
-	}
+	},
+    testOverride: function(test) {
+        var timeout = 1,
+            start;
+        test.expect(4);
+
+        start = Date.now();
+		this.cli.invoke({ timeout: timeout }, "quiet", function(error, res, more) {
+            var end = Date.now();
+            test.ok(end - start - 1000 < 30, "Timeout should be ~1 second");
+			test.equal(error.name, "TimeoutExpired");
+			test.equal(res, null);
+			test.equal(more, false);
+			test.done();
+		});
+    }
 };

--- a/test/timeouts.js
+++ b/test/timeouts.js
@@ -56,15 +56,15 @@ module.exports = {
 			test.done();
 		});
 	},
-    testOverride: function(test) {
-        var timeout = 1,
-            start;
-        test.expect(4);
+	testOverride: function(test) {
+		var timeout = 1,
+			start;
+		test.expect(4);
 
-        start = Date.now();
+		start = Date.now();
 		this.cli.invoke({ timeout: timeout }, "quiet", function(error, res, more) {
-            var end = Date.now();
-            test.ok(end - start - 1000 < 30, "Timeout should be ~1 second");
+			var end = Date.now();
+			test.ok(end - start - 1000 < 30, "Timeout should be ~1 second");
 			test.equal(error.name, "TimeoutExpired");
 			test.equal(res, null);
 			test.equal(more, false);


### PR DESCRIPTION
Adds the ability to pass an options object before method to invoke in order to override options (Currently only timeout)