### PR TITLE
pin zmq to a known working version

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
         "underscore": "1.3.3",
         "msgpack": "1.0.2",
         "node-uuid": "1.3.3",
-        "zmq": "2.x"
+        "zmq": "2.14.0"
     },
 
     "devDependencies": {


### PR DESCRIPTION
since zmq is so essential to zerorpc working correctly, i think we should pin the version to a known working version
for example, right now, zmq 2.15.0 doesnt work, see https://github.com/JustinTulloss/zeromq.node/issues/523

over time, when zmq gets upgraded, zerorpc could do testing and bump the pinned version to newer known working versions

can you also do a release after this is pinned? so that people can upgrade to the newer zerorpc and be safer?