### PR TITLE
Update uuid to version 3.0.0

### DIFF
--- a/lib/events.js
+++ b/lib/events.js
@@ -22,7 +22,7 @@
 // DEALINGS IN THE SOFTWARE.
 
 var msgpack = require("msgpack"),
-    uuid = require("node-uuid");
+    uuid = require("uuid");
 
 //Serializes an event into an array of buffers that can be transmitted
 //through ZeroMQ.

--- a/package.json
+++ b/package.json
@@ -1,43 +1,41 @@
 {
-    "name": "zerorpc",
-    "version": "0.9.6",
-    "main": "./index.js",
-    "author": "François-Xavier Bourlet <bombela+zerorpc@gmail.com>",
-    "description": "A port of ZeroRPC to node.js",
-
-    "contributors": [{
-        "name": "Francois-Xavier Bourlet",
-        "email": "bombela@gmail.com"
-    },{
-        "name": "Yusuf Simonson",
-        "email": "simonson@gmail.com"
-    }],
-    "scripts": {
-      "test": "./node_modules/.bin/nodeunit test"
+  "name": "zerorpc",
+  "version": "0.9.6",
+  "main": "./index.js",
+  "author": "François-Xavier Bourlet <bombela+zerorpc@gmail.com>",
+  "description": "A port of ZeroRPC to node.js",
+  "contributors": [
+    {
+      "name": "Francois-Xavier Bourlet",
+      "email": "bombela@gmail.com"
     },
-    "repository": {
-        "type": "git",
-        "url": "https://github.com/0rpc/zerorpc-node"
-    },
-
-    "keywords": [
-        "zerorpc",
-        "rpc",
-        "distributed",
-        "communication"
-    ],
-
-    "dependencies": {
-        "underscore": "1.3.3",
-        "msgpack": "1.0.2",
-        "node-uuid": "^1.4.7",
-        "zmq": "2.x"
-    },
-
-    "devDependencies": {
-        "nodeunit": "0.9.1",
-		"temp": "0.8.1"
-	},
-
-    "license": "MIT"
+    {
+      "name": "Yusuf Simonson",
+      "email": "simonson@gmail.com"
+    }
+  ],
+  "scripts": {
+    "test": "./node_modules/.bin/nodeunit test"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/0rpc/zerorpc-node"
+  },
+  "keywords": [
+    "zerorpc",
+    "rpc",
+    "distributed",
+    "communication"
+  ],
+  "dependencies": {
+    "msgpack": "1.0.2",
+    "underscore": "1.3.3",
+    "uuid": "^3.0.0",
+    "zmq": "2.x"
+  },
+  "devDependencies": {
+    "nodeunit": "0.9.1",
+    "temp": "0.8.1"
+  },
+  "license": "MIT"
 }


### PR DESCRIPTION
## Version 3.0.0 of [uuid](https://github.com/kelektiv/node-uuid) just got published.

Hi there,

This week a new version of the [uuid](https://github.com/kelektiv/node-uuid) module got released. The old module which was available by the name [node-uuid](https://www.npmjs.com/package/node-uuid) got deprecated and will show error message upon every install of the module.

To get rid of those install errors I've created this **automated pull request**. I've run some checks against your code base to test whether you're using one of the [deprecated apis](https://github.com/kelektiv/node-uuid/commit/5ae7287fc935eb55ef39133e4be17ef623ca000e), but this isn't the case.


Please test the changes against your code. I didn't run any tests and therefore can't guarantee that it isn't breaking. You can also just close this pr if you don't want to update your module.

In case there's already another pr open to upgrade uuid, I'm sorry for the effort I'm causing.