### PR TITLE
Added documentation on invoking methods with arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,7 @@ Methods:
 * `close()` - Closes the ZeroMQ socket.
 * `invoke(method, arguments..., callback)` - Invokes a remote method.
   * `method` is the method name.
+  * `arguments` are a list of arguments passed to the method, if there are no arguments then this argument is ommitted
   * `callback` is a method to call when there is an update. This callback is called as `callback(error, response, more)`, where error is an error object, response is the new update, and more is a boolean specifying whether new updates will be available later (i.e. whether the response is streaming).
 
 Full example:


### PR DESCRIPTION
I had difficulties finding how to pass arguments without parameters, and saw there wasn't really anything describing it in here. Hopefully this can help people not waste 20 minutes like I did trying to figure out how to do this as a lot of the documentation says to pass an empty array which is incorrect.