### PR TITLE
switch zmq -> zeromq, msgpack -> msgpack-lite

### DIFF
--- a/lib/events.js
+++ b/lib/events.js
@@ -21,7 +21,7 @@
 // FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 // DEALINGS IN THE SOFTWARE.
 
-var msgpack = require("msgpack"),
+var msgpack = require("msgpack-lite"),
     uuid = require("uuid");
 
 //Serializes an event into an array of buffers that can be transmitted
@@ -39,7 +39,7 @@ function serialize(event) {
     }
 
     message.push(new Buffer(0));
-    message.push(msgpack.pack(payload));
+    message.push(msgpack.encode(payload));
     return message;
 }
 
@@ -51,7 +51,7 @@ function serialize(event) {
 //return : Object
 //      The deserialized object
 function deserialize(envelope, payload) {
-    var event = msgpack.unpack(arguments[arguments.length - 1]);
+    var event = msgpack.decode(arguments[arguments.length - 1]);
 
     if(!(event instanceof Array) || event.length != 3) {
         throw new Error("Expected array of size 3");

--- a/lib/socket.js
+++ b/lib/socket.js
@@ -22,7 +22,7 @@
 // DEALINGS IN THE SOFTWARE.
 
 var nodeUtil = require("util"),
-    zmq = require("zmq"),
+    zmq = require("zeromq"),
     nodeEvents = require("events"),
     events = require("./events"),
     util = require("./util"),

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "msgpack-lite": "^0.1.26",
     "underscore": "1.3.3",
     "uuid": "^3.0.0",
-    "zeromq": "^4.1.1"
+    "zeromq": "^4.6.0"
   },
   "devDependencies": {
     "nodeunit": "0.9.1",

--- a/package.json
+++ b/package.json
@@ -28,10 +28,10 @@
     "communication"
   ],
   "dependencies": {
-    "msgpack": "1.0.2",
+    "msgpack-lite": "^0.1.26",
     "underscore": "1.3.3",
     "uuid": "^3.0.0",
-    "zmq": "2.x"
+    "zeromq": "^4.1.1"
   },
   "devDependencies": {
     "nodeunit": "0.9.1",


### PR DESCRIPTION
I was trying zerorpc in Windows, it's VERY annoying to configure the `node-gyp` / C++ compiler environment.

Then I tried to find the alternatives: [`zeromq.js`](https://github.com/zeromq/zeromq.js) is a better alternative to `zeromq.node`, and most importantly it provides prebuilt binaries for all major platforms! No need to install c++ compilers!

Similarly, [`msgpack-lite`](https://github.com/kawanet/msgpack-lite) is a pure js alternative to `msgpack` using c++ codes. It claims to be faster than `msgpack`.

`npm test` seems to have no problems.