### PR TITLE
change msgpack to msgpack-lite

### DIFF
--- a/lib/events.js
+++ b/lib/events.js
@@ -21,7 +21,7 @@
 // FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 // DEALINGS IN THE SOFTWARE.
 
-var msgpack = require("msgpack"),
+var msgpack = require("msgpack-lite"),
     uuid = require("uuid");
 
 //Serializes an event into an array of buffers that can be transmitted
@@ -39,7 +39,7 @@ function serialize(event) {
     }
 
     message.push(new Buffer(0));
-    message.push(msgpack.pack(payload));
+    message.push(msgpack.encode(payload));
     return message;
 }
 
@@ -51,7 +51,7 @@ function serialize(event) {
 //return : Object
 //      The deserialized object
 function deserialize(envelope, payload) {
-    var event = msgpack.unpack(arguments[arguments.length - 1]);
+    var event = msgpack.decode(arguments[arguments.length - 1]);
 
     if(!(event instanceof Array) || event.length != 3) {
         throw new Error("Expected array of size 3");

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "zerorpc",
+  "name": "zerorpc-x",
   "version": "0.9.7",
   "main": "./index.js",
   "author": "François-Xavier Bourlet <bombela+zerorpc@gmail.com>",
@@ -19,7 +19,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/0rpc/zerorpc-node"
+    "url": "https://github.com/stanleyxu2005/zerorpc-node"
   },
   "keywords": [
     "zerorpc",
@@ -28,10 +28,10 @@
     "communication"
   ],
   "dependencies": {
-    "msgpack-lite": "0.1.26",
-    "underscore": "1.3.3",
-    "uuid": "^3.0.0",
-    "zmq": "2.x"
+    "msgpack-lite": "latest",
+    "underscore": "latest",
+    "uuid": "latest",
+    "zmq": "latest"
   },
   "devDependencies": {
     "nodeunit": "0.9.1",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "communication"
   ],
   "dependencies": {
-    "msgpack": "1.0.2",
+    "msgpack-lite": "0.1.26",
     "underscore": "1.3.3",
     "uuid": "^3.0.0",
     "zmq": "2.x"


### PR DESCRIPTION
Proposed in #86. This is a pure javascript implementation. The benefit is no longer need to build msgpack on individual platform.