### PR TITLE
ZeroMQ v6 compatibility update

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,8 @@ Events:
 Methods:
 
 * `bind(endpoint)` - Binds the server to the specified ZeroMQ endpoint.
+                     Returns `Promise<void>`, which is resolved when the
+                     socket was successfully bound (new in v0.9.9.beta).
 * `connect(endpoint)` - Connects the server to the specified ZeroMQ endpoint.
 * `close()` - Closes the ZeroMQ socket.
 
@@ -100,7 +102,9 @@ Events:
 
 Methods:
 
-* `bind(endpoint)` - Binds the client to the specified ZeroMQ endpoint.
+* `bind(endpoint)` - Binds the client to the specified ZeroMQ endpoint. Returns
+                     `Promise<void>`, which is resolved when the socket was
+                     successfully bound (new in v0.9.9.beta).
 * `connect(endpoint)` - Connects the client to the specified ZeroMQ endpoint.
 * `close()` - Closes the ZeroMQ socket.
 * `invoke(method, arguments..., callback)` - Invokes a remote method.

--- a/lib/client.js
+++ b/lib/client.js
@@ -51,11 +51,13 @@ function Client(options) {
 
 nodeUtil.inherits(Client, events.EventEmitter);
 
-//Binds to a ZeroMQ endpoint
+//Binds to a ZeroMQ endpoint (async)
 //endpoint : String
 //      The ZeroMQ endpoint
+//return : Promise<void>
+//      Resolved when the socket was successfully bound.
 Client.prototype.bind = function(endpoint) {
-    this._socket.bind(endpoint);
+    return this._socket.bind(endpoint);
 };
 
 //Connects to a ZeroMQ endpoint

--- a/lib/events.js
+++ b/lib/events.js
@@ -38,7 +38,7 @@ function serialize(event) {
         message = message.concat(event.envelope);
     }
 
-    message.push(new Buffer(0));
+    message.push(new Buffer.alloc(0));
     message.push(msgpack.encode(payload));
     return message;
 }

--- a/lib/server.js
+++ b/lib/server.js
@@ -192,11 +192,13 @@ Server.prototype._recv = function(event, context) {
     }
 }
 
-//Binds to a ZeroMQ endpoint
+//Binds to a ZeroMQ endpoint (async)
 //endpoint : String
 //      The ZeroMQ endpoint
+//return : Promise<void>
+//      Resolved when the socket was successfully bound.
 Server.prototype.bind = function(endpoint) {
-    this._socket.bind(endpoint);
+    return this._socket.bind(endpoint);
 };
 
 //Connects to a ZeroMQ endpoint

--- a/lib/socket.js
+++ b/lib/socket.js
@@ -22,7 +22,7 @@
 // DEALINGS IN THE SOFTWARE.
 
 var nodeUtil = require("util"),
-    zmq = require("zeromq"),
+    zmq = require("zeromq/v5-compat"),
     nodeEvents = require("events"),
     events = require("./events"),
     util = require("./util"),
@@ -72,12 +72,19 @@ Socket.prototype.send = function(event) {
     this._zmqSocket.send.call(this._zmqSocket, message);
 };
 
-//Binds to a ZeroMQ endpoint
+//Binds to a ZeroMQ endpoint (async)
 //endpoint : String
 //      The ZeroMQ endpoint
+//return : Promise<void>
+//      Resolved when the socket was successfully bound.
 Socket.prototype.bind = function(endpoint) {
-    this._zmqSocket.bindSync(endpoint);
-}
+  return new Promise((resolve, reject) => {
+    this._zmqSocket.bind(endpoint, err => {
+      if (err) reject(err);
+      resolve();
+    });
+  });
+};
 
 //Connects to a ZeroMQ endpoint
 //endpoint : String

--- a/package.json
+++ b/package.json
@@ -29,13 +29,13 @@
   ],
   "dependencies": {
     "msgpack-lite": "^0.1.26",
-    "underscore": "1.3.3",
-    "uuid": "^3.0.0",
-    "zeromq": "^4.6.0"
+    "underscore": "^1.9.1",
+    "uuid": "^3.3.3",
+    "zeromq": "^6.0.0-beta.3"
   },
   "devDependencies": {
-    "nodeunit": "0.9.1",
-    "temp": "0.8.1"
+    "nodeunit": "^0.11.3",
+    "temp": "^0.9.1"
   },
   "license": "MIT"
 }

--- a/test/buffers.js
+++ b/test/buffers.js
@@ -36,10 +36,16 @@ module.exports = {
 				reply();
 			}
 		});
-		this.srv.bind(endpoint);
+    this.srv
+      .bind(endpoint)
+      .then(() => {
 		this.cli = new zerorpc.Client({ timeout: 5 });
 		this.cli.connect(endpoint);
 		cb();
+      })
+      .catch(err => {
+				console.error(err);
+      });
 	},
 	tearDown: function(cb) {
 		this.cli.close();

--- a/test/errors.js
+++ b/test/errors.js
@@ -55,10 +55,16 @@ module.exports = {
 			}
 		});
 
-		this.srv.bind(endpoint);
-		this.cli = new zerorpc.Client({ timeout: 5 });
-		this.cli.connect(endpoint);
-		cb();
+		this.srv
+      .bind(endpoint)
+      .then(() => {
+        this.cli = new zerorpc.Client({ timeout: 5 });
+        this.cli.connect(endpoint);
+        cb();
+      })
+      .catch(err => {
+        console.error(err)
+      });
 	},
 	tearDown: function(cb) {
 		this.cli.close();

--- a/test/heartbeats.js
+++ b/test/heartbeats.js
@@ -45,14 +45,20 @@ module.exports = {
 				}, 250);
 			}
 		}, heartbeat);
-		this.srv.bind(endpoint);
 		this.srv.on('error', function(err) {
 			//console.log('on error', err);
 		});
-		this.cli = new zerorpc.Client({ timeout: 11000, heartbeat: heartbeat });
-		this.cli.connect(endpoint);
-		this.killed = false;
-		cb();
+		this.srv
+      .bind(endpoint)
+      .then(() => {
+        this.cli = new zerorpc.Client({ timeout: 11000, heartbeat: heartbeat });
+        this.cli.connect(endpoint);
+        this.killed = false;
+        cb();
+      })
+      .catch(err => {
+        console.error(err)
+      });
 	},
 	tearDown: function(cb) {
 		if (!this.cli.closed()) {

--- a/test/invocation.js
+++ b/test/invocation.js
@@ -37,10 +37,16 @@ module.exports = {
 				reply(null, n + 42, false);
 			}
 		});
-		this.srv.bind(endpoint);
-		this.cli = new zerorpc.Client({ timeout: 5 });
-		this.cli.connect(endpoint);
-		cb();
+		this.srv
+      .bind(endpoint)
+      .then(() => {
+        this.cli = new zerorpc.Client({ timeout: 5 });
+        this.cli.connect(endpoint);
+        cb();
+      })
+      .catch(err => {
+        console.error(err)
+      });
 	},
 	tearDown: function(cb) {
 		this.cli.close();

--- a/test/repro-10.js
+++ b/test/repro-10.js
@@ -35,7 +35,9 @@ module.exports = {
 			}
 		});
 
-		srv.bind(endpoint);
+    srv
+      .bind(endpoint)
+      .then(() => {
 		cli = new zerorpc.Client({ timeout: 5 });
 
 		setTimeout(function() {
@@ -49,5 +51,9 @@ module.exports = {
 				test.done();
 			});
 		}, 10000);
+      })
+      .catch(err => {
+        console.error(err)
+      });
 	}
 };

--- a/test/streams.js
+++ b/test/streams.js
@@ -60,10 +60,16 @@ module.exports = {
 				}, 1000);
 			}
 		});
-		this.srv.bind(endpoint);
-		this.cli = new zerorpc.Client({ timeout: 5 });
-		this.cli.connect(endpoint);
-		cb();
+		this.srv
+      .bind(endpoint)
+      .then(() => {
+        this.cli = new zerorpc.Client({ timeout: 5 });
+        this.cli.connect(endpoint);
+        cb();
+      })
+      .catch(err => {
+        console.error(err)
+      });
 	},
 	tearDown: function(cb) {
 		this.cli.close();

--- a/test/timeouts.js
+++ b/test/timeouts.js
@@ -36,10 +36,16 @@ module.exports = {
 				}, 6 * 1000);
 			}
 		});
-		this.srv.bind(endpoint);
-		this.cli = new zerorpc.Client({ timeout: 5 });
-		this.cli.connect(endpoint);
-		cb();
+		this.srv
+      .bind(endpoint)
+      .then(() => {
+        this.cli = new zerorpc.Client({ timeout: 5 });
+        this.cli.connect(endpoint);
+        cb();
+      })
+      .catch(err => {
+        console.error(err)
+      });
 	},
 	tearDown: function(cb) {
 		this.cli.close();


### PR DESCRIPTION
This PR is to make zerorpc to work with upcoming zeroMQ v6 (currently in beta3). 

* Uses ZeroMQ v6's compatibility layer for ZeroMQ.js versions 4 and 5
* To my limited knowledge, the only deprecation that affected zerorpc is `Socket.bindSync()`. The PR replaces it with `bind()` and returns a promise, which resolves when the socket is successfully bound.
* Unit test files are updated to the new server bind() calls
* All tests were successfully completed in Windows 10, Node 13.1 (see below for testing in Windows)
* Documentation has been updated to reflect the change in bind() behavior
* Dependent packages are all updated to the current versions
* Updated the Buffer instantiation to avoid using the deprecated constructor

With the ZeroMQ v6 still in beta, I'm not sure if this PR should be merged at this very moment, but since ZeroMQ v5 does not build successfully under Node v13.1 I thought this is needed to be done sooner rather than later.

(Testing in Windows) Because Windows does not support ipc protocol, I had to modify `random_ipc_endpoint()` in `test\lib\testutil.js` to create a localhost tcp endpoint with random port if Windows. If there is a interest for this addition, I can create another PR for it as well.