### PR TITLE
Update package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   "dependencies": {
     "msgpack-lite": "^0.1.26",
     "underscore": "1.3.3",
-    "uuid": "^3.0.0",
+    "uuid": "^7.0.0",
     "zeromq": "^4.6.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Bumping up UUID version to 7.0.0 as per install errors.
---
npm WARN deprecated uuid@3.4.0: Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.
⸨##################⸩ ⠸ reify:msgpack-lite: timing reifyNode:node_modules/tar-fs Completed in 272ms

----